### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/BACKEND/src/controllers/user.controller.js
+++ b/BACKEND/src/controllers/user.controller.js
@@ -109,7 +109,7 @@ const loginUser = asynchandler(async (req, res) => {
   }
 
   const isPasswordValid = await user.isPasswordCorrect(password);
-  console.log("Password Valid:", isPasswordValid)
+  // Removed logging of isPasswordValid to avoid exposing sensitive information
   if (!isPasswordValid) {
     throw new ApiError(401, "Invalid User Credentials");
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Steve-Wayne/EICHackathon/security/code-scanning/7](https://github.com/Steve-Wayne/EICHackathon/security/code-scanning/7)

To fix the issue, we should remove the logging of the `isPasswordValid` variable entirely. Debugging information related to password validation should not be logged, even in development environments, to avoid accidental exposure of sensitive information. If debugging is necessary, consider using a secure logging mechanism that redacts sensitive data or logs only non-sensitive information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
