### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/BACKEND/package.json
+++ b/BACKEND/package.json
@@ -31,7 +31,8 @@
     "mongoose": "^8.12.1",
     "mongoose-aggregate-paginate-v2": "^1.1.3",
     "multer": "^1.4.5-lts.1",
-    "lusca": "^1.7.0"
+    "lusca": "^1.7.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/BACKEND/src/routes/user.routes.js
+++ b/BACKEND/src/routes/user.routes.js
@@ -5,9 +5,18 @@ import { logoutUser } from "../controllers/user.controller.js";
 import { verifyJWT } from "../middleware/auth.middleware.js";
 import { refreshAccessToken } from "../controllers/user.controller.js";
 import { changeCurrentPassword } from "../controllers/user.controller.js";
+import rateLimit from "express-rate-limit";
+
 const router = Router();
 
-router.route("/register").post(registerUser);
+// Rate limiter for the /register route
+const registerRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: "Too many accounts created from this IP, please try again after 15 minutes",
+});
+
+router.route("/register").post(registerRateLimiter, registerUser);
 
 router.route("/login").post(loginUser);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Steve-Wayne/EICHackathon/security/code-scanning/1](https://github.com/Steve-Wayne/EICHackathon/security/code-scanning/1)

To fix the issue, we will add rate limiting to the `registerUser` route using the `express-rate-limit` package. This package allows us to define a maximum number of requests per time window for specific routes. We will configure a rate limiter with reasonable limits (e.g., 100 requests per 15 minutes) and apply it to the `/register` route.

Steps:
1. Install the `express-rate-limit` package if not already installed.
2. Import the package in the file.
3. Define a rate limiter with appropriate settings.
4. Apply the rate limiter middleware to the `/register` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
